### PR TITLE
refactor modifiers in MicroUMLClassNode and MicroUMLMemberNode

### DIFF
--- a/src/MicroUML-AST/MicroUMLClassNode.class.st
+++ b/src/MicroUML-AST/MicroUMLClassNode.class.st
@@ -11,10 +11,7 @@ Class {
 		'name',
 		'superclass',
 		'members',
-		'attributes',
-		'methods',
-		'isAbstract',
-		'modifiers'
+		'isAbstract'
 	],
 	#category : 'MicroUML-AST',
 	#package : 'MicroUML-AST'
@@ -262,14 +259,15 @@ MicroUMLClassNode >> methodsDo: aBlock [
 { #category : 'accessing' }
 MicroUMLClassNode >> modifiers [
 
-	^ modifiers
+	^ (Array streamContents: [ :stream |
+		   self isAbstract ifTrue: [ stream nextPut: #abstract ] ])
+		  ifEmpty: [ nil ]
 ]
 
 { #category : 'accessing' }
 MicroUMLClassNode >> modifiers: anArrayOfSymbol [
 
-	modifiers := anArrayOfSymbol.
-	(modifiers includes: #abstract) ifTrue: [ self beAbstract ]
+	(anArrayOfSymbol includes: #abstract) ifTrue: [ self beAbstract ]
 ]
 
 { #category : 'accessing' }

--- a/src/MicroUML-AST/MicroUMLClassNode.class.st
+++ b/src/MicroUML-AST/MicroUMLClassNode.class.st
@@ -267,7 +267,7 @@ MicroUMLClassNode >> modifiers [
 { #category : 'accessing' }
 MicroUMLClassNode >> modifiers: anArrayOfSymbol [
 
-	(anArrayOfSymbol includes: #abstract) ifTrue: [ self beAbstract ]
+	isAbstract := anArrayOfSymbol includes: #abstract
 ]
 
 { #category : 'accessing' }

--- a/src/MicroUML-AST/MicroUMLMemberNode.class.st
+++ b/src/MicroUML-AST/MicroUMLMemberNode.class.st
@@ -153,15 +153,17 @@ MicroUMLMemberNode >> isPublic [
 { #category : 'accessing' }
 MicroUMLMemberNode >> modifiers [
 
-	^ modifiers
+	^ (Array streamContents: [ :stream |
+			   self isAbstract ifTrue: [ stream nextPut: #abstract ].
+			   self isClassSide ifTrue: [ stream nextPut: #static ] ])
+		  ifEmpty: [ nil ]
 ]
 
 { #category : 'accessing' }
 MicroUMLMemberNode >> modifiers: anArrayOfSymbol [
 
-	modifiers := anArrayOfSymbol.
-	(modifiers includes: #abstract) ifTrue: [ self beAbstract ].
-	(modifiers includes: #static) ifTrue: [ self beClassSide ]
+	(anArrayOfSymbol includes: #abstract) ifTrue: [ self beAbstract ].
+	(anArrayOfSymbol includes: #static) ifTrue: [ self beClassSide ]
 ]
 
 { #category : 'accessing' }

--- a/src/MicroUML-AST/MicroUMLMemberNode.class.st
+++ b/src/MicroUML-AST/MicroUMLMemberNode.class.st
@@ -162,8 +162,8 @@ MicroUMLMemberNode >> modifiers [
 { #category : 'accessing' }
 MicroUMLMemberNode >> modifiers: anArrayOfSymbol [
 
-	(anArrayOfSymbol includes: #abstract) ifTrue: [ self beAbstract ].
-	(anArrayOfSymbol includes: #static) ifTrue: [ self beClassSide ]
+	isAbstract := anArrayOfSymbol includes: #abstract.
+	isClassSide := anArrayOfSymbol includes: #static
 ]
 
 { #category : 'accessing' }

--- a/src/MicroUML-Tests/MicroUMLMemberNodeTest.class.st
+++ b/src/MicroUML-Tests/MicroUMLMemberNodeTest.class.st
@@ -120,7 +120,7 @@ MicroUMLMemberNodeTest >> testModifiers [
 	self assert: member modifiers equals: #( abstract ).
 	self deny: member isClassSide.
 	member modifiers: #( static ).
-	self assert: member isAbstract.
+	self deny: member isAbstract.
 	self assert: member isClassSide.
 	self assert: member modifiers equals: #( static )
 ]


### PR DESCRIPTION
Currently, MicroUMLClassNode and MicroUMLMember node has the instance variable `modifiers`.
These classes also have boolean variables such as `isAbstract` and `isStatic` set by `modifiers:` setters and also AST builders.
By removing the `modifiers` variable, we can keep better consistency.