### PR TITLE
add generator that construct a MicroUML diagram AST from existing class

### DIFF
--- a/src/MicroUML-AST/MicroUMLAssociationNode.class.st
+++ b/src/MicroUML-AST/MicroUMLAssociationNode.class.st
@@ -56,16 +56,13 @@ MicroUMLAssociationNode >> leftLabel: aStringOrNil [
 ]
 
 { #category : 'printing' }
-MicroUMLAssociationNode >> printMicroUMLOn: aStream [
+MicroUMLAssociationNode >> printMicroUMLInLeftClassOn: aStream [
 
 	| heads |
 	heads := {
 		         (#composition -> '<*>').
 		         (#aggregation -> '<>') } asDictionary.
-	leftClass storeOn: aStream.
-	aStream
-		space;
-		nextPutAll: (heads at: leftHead ifAbsent: [ '' ]).
+	aStream nextPutAll: (heads at: leftHead ifAbsent: [ '' ]).
 	leftLabel ifNotNil: [
 			aStream nextPut: $<.
 			leftLabel storeOn: aStream.
@@ -79,6 +76,14 @@ MicroUMLAssociationNode >> printMicroUMLOn: aStream [
 		nextPutAll: (heads at: rightHead ifAbsent: [ '' ]);
 		space.
 	rightClass storeOn: aStream
+]
+
+{ #category : 'printing' }
+MicroUMLAssociationNode >> printMicroUMLOn: aStream [
+
+	leftClass storeOn: aStream.
+	aStream space.
+	self printMicroUMLInLeftClassOn: aStream
 ]
 
 { #category : 'accessing' }

--- a/src/MicroUML-AST/MicroUMLAstNode.class.st
+++ b/src/MicroUML-AST/MicroUMLAstNode.class.st
@@ -4,3 +4,15 @@ Class {
 	#category : 'MicroUML-AST',
 	#package : 'MicroUML-AST'
 }
+
+{ #category : 'printing' }
+MicroUMLAstNode >> microUML [
+
+	^ String streamContents: [ :stream | self printMicroUMLOn: stream ]
+]
+
+{ #category : 'printing' }
+MicroUMLAstNode >> printMicroUMLOn: aStream [
+
+	^ self subclassResponsibility
+]

--- a/src/MicroUML-AST/MicroUMLClassDiagramNode.class.st
+++ b/src/MicroUML-AST/MicroUMLClassDiagramNode.class.st
@@ -93,3 +93,61 @@ MicroUMLClassDiagramNode >> initialize [
 	classes := OrderedDictionary new.
 	associations := OrderedDictionary new
 ]
+
+{ #category : 'printing' }
+MicroUMLClassDiagramNode >> printMicroUMLOn: aStream [
+
+	self printMicroUMLOn: aStream associationsUnderClasses: true
+]
+
+{ #category : 'printing' }
+MicroUMLClassDiagramNode >> printMicroUMLOn: aStream associationsUnderClasses: aBoolean [
+
+	aBoolean = true
+		ifTrue: [ self printMicroUMLWithAssociationsUnderClassesOn: aStream ]
+		ifFalse: [
+		self printMicroUMLWithAssociationsOutsideClassesOn: aStream ]
+]
+
+{ #category : 'printing' }
+MicroUMLClassDiagramNode >> printMicroUMLWithAssociationsOutsideClassesOn: aStream [
+
+	aStream nextPutAll: self astBuilderClass name.
+	self classesDo: [ :classNode |
+			classNode isEmptyDefinition ifFalse: [
+					aStream
+						cr;
+						nextPutAll: '===';
+						cr.
+					classNode printMicroUMLOn: aStream ] ].
+	self associationsDo: [ :associationNode |
+			aStream
+				cr;
+				nextPutAll: '===';
+				cr.
+			associationNode printMicroUMLOn: aStream ]
+]
+
+{ #category : 'printing' }
+MicroUMLClassDiagramNode >> printMicroUMLWithAssociationsUnderClassesOn: aStream [
+
+	aStream nextPutAll: self astBuilderClass name.
+	self classesDo: [ :classNode |
+			aStream
+				cr;
+				nextPutAll: '===';
+				cr.
+			classNode printMicroUMLOn: aStream.
+			(self associationsForLeftClass: classNode name) ifNotEmpty: [
+					:assocs |
+					(classNode isEmptyDefinition and: [ assocs size = 1 ])
+						ifTrue: [
+								aStream space.
+								assocs first printMicroUMLInLeftClassOn: aStream ]
+						ifFalse: [
+								assocs do: [ :associationNode |
+										aStream
+											cr;
+											nextPutAll: '  '.
+										associationNode printMicroUMLInLeftClassOn: aStream ] ] ] ]
+]

--- a/src/MicroUML-AST/MicroUMLClassNode.class.st
+++ b/src/MicroUML-AST/MicroUMLClassNode.class.st
@@ -43,6 +43,14 @@ MicroUMLClassNode >> addMember: aSymbolOrNil [
 	^ members add: (self memberNodeClass new name: aSymbolOrNil)
 ]
 
+{ #category : 'adding' }
+MicroUMLClassNode >> addMethod: aSymbolOrNil [
+
+	^ members add: (self memberNodeClass new
+			   name: aSymbolOrNil;
+			   isMethod: true)
+]
+
 { #category : 'converting' }
 MicroUMLClassNode >> asRSShape [
 
@@ -88,10 +96,10 @@ MicroUMLClassNode >> asRSShape [
 { #category : 'accessing' }
 MicroUMLClassNode >> attributeAt: aSymbol [
 
-	^ (self memberAt: aSymbol) ifNotNil: [ :member |
-			  member isAttribute
-				  ifTrue: [ member ]
-				  ifFalse: [ nil ] ]
+	^ members
+		  detect: [ :member |
+		  member name = aSymbol and: [ member isAttribute ] ]
+		  ifNone: [ nil ]
 ]
 
 { #category : 'accessing' }
@@ -195,10 +203,10 @@ MicroUMLClassNode >> membersDo: aBlock [
 { #category : 'accessing' }
 MicroUMLClassNode >> methodAt: aSymbol [
 
-	^ (self memberAt: aSymbol) ifNotNil: [ :member |
-			  member isMethod
-				  ifTrue: [ member ]
-				  ifFalse: [ nil ] ]
+	^ members
+		  detect: [ :member |
+		  member name = aSymbol and: [ member isMethod ] ]
+		  ifNone: [ nil ]
 ]
 
 { #category : 'accessing' }
@@ -244,6 +252,30 @@ MicroUMLClassNode >> name [
 MicroUMLClassNode >> name: aSymbol [
 
 	name := aSymbol asSymbol
+]
+
+{ #category : 'printing' }
+MicroUMLClassNode >> printMicroUMLOn: aStream [
+
+	self modifiers ifNotNil: [ :modifiers |
+			aStream nextPutAll: '{ '.
+			modifiers
+				do: [ :modifier | modifier storeOn: aStream ]
+				separatedBy: [ aStream nextPutAll: ' . ' ].
+			aStream nextPutAll: ' } % ' ].
+	self name asSymbol storeOn: aStream.
+	self superclass ifNotNil: [ :superclassName |
+			aStream nextPutAll: ' --|> '.
+			superclassName asSymbol storeOn: aStream ].
+	self members ifNotEmpty: [
+			aStream cr.
+			self members
+				do: [ :member |
+						aStream
+							space;
+							space.
+						member printMicroUMLOn: aStream ]
+				separatedBy: [ aStream cr ] ]
 ]
 
 { #category : 'accessing' }

--- a/src/MicroUML-AST/MicroUMLMemberNode.class.st
+++ b/src/MicroUML-AST/MicroUMLMemberNode.class.st
@@ -177,6 +177,41 @@ MicroUMLMemberNode >> name: anObject [
 	name := anObject
 ]
 
+{ #category : 'printing' }
+MicroUMLMemberNode >> printMicroUMLOn: aStream [
+	" #argumentTypes  . #type   "
+
+	aStream nextPutAll: (isMethod = true
+			 ifTrue: [
+					 {
+						 (#public -> '>+ ').
+						 (#private -> '>- ') } asDictionary
+						 at: visibility
+						 ifAbsent: [ '>> ' ] ]
+			 ifFalse: [
+					 {
+						 (#public -> '+ ').
+						 (#private -> '- ') } asDictionary
+						 at: visibility
+						 ifAbsent: [ '* ' ] ]).
+	self modifiers ifNotNil: [ :symbols |
+			aStream nextPutAll: '{ '.
+			symbols
+				do: [ :symbol | symbol storeOn: aStream ]
+				separatedBy: [ aStream nextPutAll: ' . ' ].
+			aStream nextPutAll: ' } % ' ].
+	self name storeOn: aStream.
+	self argumentTypes ifNotNil: [ :symbols |
+			aStream nextPutAll: '~{ '.
+			symbols
+				do: [ :symbol | symbol storeOn: aStream ]
+				separatedBy: [ aStream nextPutAll: ' . ' ].
+			aStream nextPutAll: ' }' ].
+	self type ifNotNil: [ :symbol |
+			aStream nextPutAll: ' @ '.
+			symbol storeOn: aStream ]
+]
+
 { #category : 'accessing' }
 MicroUMLMemberNode >> type [
 

--- a/src/MicroUML-Builder/MicroUMLRoassalBuilder.class.st
+++ b/src/MicroUML-Builder/MicroUMLRoassalBuilder.class.st
@@ -470,14 +470,15 @@ MicroUMLRoassalBuilder >> renderIn: aRSCanvas [
 			nodes at: classAst name put: node ].
 	classDiagramNode classesDo: [ :classAst |
 			classAst superclass ifNotNil: [ :superclassName |
-					| link |
-					link := self
-						        newInheritanceLinkBetween: (nodes at: classAst name)
-						        andSuperclass: (nodes at: superclassName).
-					connectedNodes
-						add: (nodes at: classAst name);
-						add: (nodes at: superclassName).
-					aRSCanvas add: link ] ].
+					(nodes includesKey: superclassName) ifTrue: [
+							| link |
+							link := self
+								        newInheritanceLinkBetween: (nodes at: classAst name)
+								        andSuperclass: (nodes at: superclassName).
+							connectedNodes
+								add: (nodes at: classAst name);
+								add: (nodes at: superclassName).
+							aRSCanvas add: link ] ] ].
 	classDiagramNode associationsDo: [ :associationNode |
 			| edge leftNode rightNode |
 			leftNode := nodes at: associationNode leftClass.

--- a/src/MicroUML-Generator/MicroUMLGenerator.class.st
+++ b/src/MicroUML-Generator/MicroUMLGenerator.class.st
@@ -1,6 +1,120 @@
 Class {
 	#name : 'MicroUMLGenerator',
 	#superclass : 'Object',
+	#instVars : [
+		'diagram'
+	],
 	#category : 'MicroUML-Generator',
 	#package : 'MicroUML-Generator'
 }
+
+{ #category : 'examples' }
+MicroUMLGenerator class >> example [
+
+	(MicroUMLRoassalBuilder new classDiagramNode: (self new
+				  generateClass: self;
+				  ensureClassNamed: self superclass name;
+				  diagram)) build
+		zoomToFit;
+		@ RSCanvasController;
+		openWithTitle: self name
+]
+
+{ #category : 'class access' }
+MicroUMLGenerator >> associationNodeClass [
+
+	^ MicroUMLAssociationNode
+]
+
+{ #category : 'class access' }
+MicroUMLGenerator >> classDiagramClass [
+
+	^ MicroUMLClassDiagramNode
+]
+
+{ #category : 'class access' }
+MicroUMLGenerator >> classNodeClass [
+
+	^ MicroUMLClassNode
+]
+
+{ #category : 'accessing' }
+MicroUMLGenerator >> diagram [
+
+	^ diagram
+]
+
+{ #category : 'accessing' }
+MicroUMLGenerator >> ensureClassNamed: aSymbol [
+
+	^ diagram ensureClassNamed: aSymbol
+]
+
+{ #category : 'generating' }
+MicroUMLGenerator >> generateAttribute: aSymbol in: aClass [
+
+	| attributeNode |
+	attributeNode := (diagram ensureClassNamed: aClass name asSymbol)
+		                 addAttribute: aSymbol asSymbol.
+	aClass
+		compiledMethodAt: (aSymbol , ':') asSymbol
+		ifPresent: [ :compiledMethod |
+				| parameter |
+				parameter := compiledMethod ast arguments first name asString.
+				attributeNode type: (self guessParameterType: parameter) asSymbol ].
+	^ attributeNode
+]
+
+{ #category : 'generating' }
+MicroUMLGenerator >> generateClass: aClass [
+
+	| classNode |
+	classNode := diagram ensureClassNamed: aClass name asSymbol.
+	aClass superclass ifNotNil: [ :s |
+		classNode superclass: s name asSymbol ].
+	aClass instVarNames do: [ :var |
+		self generateAttribute: var asSymbol in: aClass ].
+	aClass selectors do: [ :selector |
+		self generateMethod: selector asSymbol in: aClass ].
+	^ classNode
+]
+
+{ #category : 'generating' }
+MicroUMLGenerator >> generateMethod: aSymbol in: aClass [
+
+	| methodNode |
+	methodNode := (diagram ensureClassNamed: aClass name asSymbol)
+		              addMethod: aSymbol asSymbol.
+	aClass
+		compiledMethodAt: aSymbol asSymbol
+		ifPresent: [ :compiledMethod |
+				methodNode argumentTypes:
+					(compiledMethod ast arguments collect: [ :arg |
+						 self guessParameterType: arg name ]) asArray ].
+	^ methodNode
+]
+
+{ #category : 'private' }
+MicroUMLGenerator >> guessParameterType: aString [
+
+	(aString size > 2 and: [
+		 (aString beginsWith: 'an') and: [ (aString at: 3) isUppercase ] ])
+		ifTrue: [ ^ (aString copyWithoutFirst: 2) asSymbol ].
+	(aString size > 1 and: [
+		 (aString beginsWith: 'a') and: [ (aString at: 2) isUppercase ] ])
+		ifTrue: [ ^ aString copyWithoutFirst asSymbol ].
+	^ aString asSymbol
+]
+
+{ #category : 'initialization' }
+MicroUMLGenerator >> initialize [
+
+	super initialize.
+	diagram := self classDiagramClass new
+]
+
+{ #category : 'class access' }
+MicroUMLGenerator >> memberNodeClass [
+
+	^ MicroUMLMemberNode
+]

--- a/src/MicroUML-Tests/MicroUMLAssociationNodeTest.class.st
+++ b/src/MicroUML-Tests/MicroUMLAssociationNodeTest.class.st
@@ -6,6 +6,24 @@ Class {
 }
 
 { #category : 'tests' }
+MicroUMLAssociationNodeTest >> testPrintMicroUMLInLeftClassOn [
+
+	| association |
+	association := (MicroUMLAstBuilder new === #Foo --- #Bar)
+		               associations first.
+	self
+		assert: (String streamContents: [ :stream |
+				 association printMicroUMLInLeftClassOn: stream ])
+		equals: '--- #Bar'.
+	association := (MicroUMLAstBuilder new === #Foo <>< 'bar' >---< 'baz'
+	                ><*> #Quuux) associations first.
+	self
+		assert: (String streamContents: [ :stream |
+				 association printMicroUMLInLeftClassOn: stream ])
+		equals: '<><''bar''>---<''baz''><*> #Quuux'
+]
+
+{ #category : 'tests' }
 MicroUMLAssociationNodeTest >> testPrintMicroUMLOn [
 
 	| association |

--- a/src/MicroUML-Tests/MicroUMLClassDiagramNodeTest.class.st
+++ b/src/MicroUML-Tests/MicroUMLClassDiagramNodeTest.class.st
@@ -1,0 +1,46 @@
+Class {
+	#name : 'MicroUMLClassDiagramNodeTest',
+	#superclass : 'TestCase',
+	#category : 'MicroUML-Tests',
+	#package : 'MicroUML-Tests'
+}
+
+{ #category : 'tests' }
+MicroUMLClassDiagramNodeTest >> testPrintMicroUMLWithAssociationsOutsideClassesOn [
+	| diagram |
+	diagram := (MicroUMLAstBuilder 
+===
+#Foo --|> #Bar
+	<>--- #Baz
+	<*>--- #Quuux
+===
+#Baz <*>--- #Quuux) diagram.
+	self assert: (String streamContents: [:stream | diagram printMicroUMLWithAssociationsOutsideClassesOn: stream]) equals: 'MicroUMLAstBuilder
+===
+#Foo --|> #Bar
+===
+#Foo <>--- #Baz
+===
+#Foo <*>--- #Quuux
+===
+#Baz <*>--- #Quuux'
+]
+
+{ #category : 'tests' }
+MicroUMLClassDiagramNodeTest >> testPrintMicroUMLWithAssociationsUnderClassesOn [
+	| diagram |
+	diagram := (MicroUMLAstBuilder 
+===
+#Foo --|> #Bar
+	<>--- #Baz
+	<*>--- #Quuux
+===
+#Baz <*>--- #Quuux) diagram.
+	self assert: (String streamContents: [:stream | diagram printMicroUMLWithAssociationsUnderClassesOn: stream]) equals: 'MicroUMLAstBuilder
+===
+#Foo --|> #Bar
+  <>--- #Baz
+  <*>--- #Quuux
+===
+#Baz <*>--- #Quuux'
+]

--- a/src/MicroUML-Tests/MicroUMLClassNodeTest.class.st
+++ b/src/MicroUML-Tests/MicroUMLClassNodeTest.class.st
@@ -229,6 +229,33 @@ MicroUMLClassNodeTest >> testName [
 ]
 
 { #category : 'tests' }
+MicroUMLClassNodeTest >> testPrintMicroUMLOn [
+
+	class := #Foo --|> #Bar classAt: #Foo.
+	self
+		assert:
+		(String streamContents: [ :stream | class printMicroUMLOn: stream ])
+		equals: '#Foo --|> #Bar'.
+	class := { #abstract } % #Foo --|> #Bar classAt: #Foo.
+	self
+		assert:
+		(String streamContents: [ :stream | class printMicroUMLOn: stream ])
+		equals: '{ #abstract } % #Foo --|> #Bar'.
+	class := 
+	#Foo --|> #Bar
+		* #baz
+		>> #quuux
+	classAt: #Foo.
+	self
+		assert:
+		(String streamContents: [ :stream | class printMicroUMLOn: stream ])
+		equals: '#Foo --|> #Bar
+  * #baz
+  >> #quuux'.
+
+]
+
+{ #category : 'tests' }
 MicroUMLClassNodeTest >> testSuperclass [
 
 	self assert: class superclass isNil.

--- a/src/MicroUML-Tests/MicroUMLGeneratorTest.class.st
+++ b/src/MicroUML-Tests/MicroUMLGeneratorTest.class.st
@@ -1,0 +1,87 @@
+Class {
+	#name : 'MicroUMLGeneratorTest',
+	#superclass : 'TestCase',
+	#instVars : [
+		'generator',
+		'dummy'
+	],
+	#category : 'MicroUML-Tests',
+	#package : 'MicroUML-Tests'
+}
+
+{ #category : 'accessing' }
+MicroUMLGeneratorTest >> dummy [
+
+	^ dummy
+]
+
+{ #category : 'accessing' }
+MicroUMLGeneratorTest >> dummy: aString [
+
+	dummy := aString
+]
+
+{ #category : 'running' }
+MicroUMLGeneratorTest >> setUp [
+
+	generator := MicroUMLGenerator new
+]
+
+{ #category : 'running' }
+MicroUMLGeneratorTest >> testGenerateAttributeIn [
+
+	| attribute |
+	generator generateAttribute: #dummy in: self class.
+	attribute := (generator diagram classAt: self class name) attributeAt:
+		             #dummy.
+	self assert: attribute isAttribute.
+	self assert: attribute name equals: #dummy.
+	self assert: attribute type equals: #String
+]
+
+{ #category : 'running' }
+MicroUMLGeneratorTest >> testGenerateClass [
+
+	| attribute getter setter |
+	generator generateClass: self class.
+	attribute := (generator diagram classAt: self class name)
+		             attributeAt: #dummy.
+	self assert: attribute isAttribute.
+	self assert: attribute name equals: #dummy.
+	self assert: attribute argumentTypes isNil.
+	self assert: attribute type equals: #String.
+
+	getter := (generator diagram classAt: self class name) methodAt:
+		          #dummy.
+	self assert: getter isMethod.
+	self assert: getter name equals: #dummy.
+	self assert: getter argumentTypes equals: #(  ).
+	self assert: getter type isNil.
+
+	setter := (generator diagram classAt: self class name) methodAt:
+		          #dummy:.
+	self assert: setter isMethod.
+	self assert: setter name equals: #dummy:.
+	self assert: setter argumentTypes equals: #( String ).
+	self assert: setter type isNil
+]
+
+{ #category : 'running' }
+MicroUMLGeneratorTest >> testGenerateMethodIn [
+
+	| method |
+	generator generateMethod: #dummy: in: self class.
+	method := (generator diagram classAt: self class name) methodAt:
+		          #dummy:.
+	self assert: method isMethod.
+	self assert: method name equals: #dummy:.
+	self assert: method argumentTypes equals: #( String ).
+	self assert: method type isNil.
+	generator generateMethod: #dummy in: self class.
+	method := (generator diagram classAt: self class name) methodAt:
+		          #dummy.
+	self assert: method isMethod.
+	self assert: method name equals: #dummy.
+	self assert: method argumentTypes equals: #(  ).
+	self assert: method type isNil
+]

--- a/src/MicroUML-Tests/MicroUMLMemberNodeTest.class.st
+++ b/src/MicroUML-Tests/MicroUMLMemberNodeTest.class.st
@@ -133,6 +133,27 @@ MicroUMLMemberNodeTest >> testName [
 ]
 
 { #category : 'tests' }
+MicroUMLMemberNodeTest >> testPrintMicroUMLOn [
+
+	member := (#Quuux * #foo classAt: #Quuux) memberAt: #foo.
+	self
+		assert:
+		(String streamContents: [ :stream | member printMicroUMLOn: stream ])
+		equals: '* #foo'.
+	member := (#Quuux + {#abstract . #static} % #foo @ #Bar classAt: #Quuux) memberAt: #foo.
+	self
+		assert:
+		(String streamContents: [ :stream | member printMicroUMLOn: stream ])
+		equals: '+ { #abstract . #static } % #foo @ #Bar'.
+	member := (#Quuux >- {#abstract . #static} % #foo ~ {#Bar} @ #Baz classAt: #Quuux) memberAt: #foo.
+	self
+		assert:
+		(String streamContents: [ :stream | member printMicroUMLOn: stream ])
+		equals: '>- { #abstract . #static } % #foo~{ #Bar } @ #Baz'.
+
+]
+
+{ #category : 'tests' }
 MicroUMLMemberNodeTest >> testType [
 
 	member type: #Foo.


### PR DESCRIPTION
The following expression will construct a MicroUML AST from Smalltalk's `Foo` class and show it in Roassal.
```
| generator |
generator := MicroUMLGenerator new.
generator
    generateClass: Foo;
    ensureClassNamed: Foo superclass name.
(MicroUMLRoassalBuilder new
    classDiagramNode: generator diagram;
    build)
		zoomToFit;
		@ RSCanvasController;
		open
```