### PR TITLE
add actionBlock and comments to the grammar and roassal UI

### DIFF
--- a/src/MicroUML-AST/MicroUMLAstNode.class.st
+++ b/src/MicroUML-AST/MicroUMLAstNode.class.st
@@ -1,9 +1,25 @@
 Class {
 	#name : 'MicroUMLAstNode',
 	#superclass : 'Object',
+	#instVars : [
+		'comment',
+		'actionBlock'
+	],
 	#category : 'MicroUML-AST',
 	#package : 'MicroUML-AST'
 }
+
+{ #category : 'accessing' }
+MicroUMLAstNode >> actionBlock [
+
+	^ actionBlock
+]
+
+{ #category : 'accessing' }
+MicroUMLAstNode >> actionBlock: aBlock [
+
+	actionBlock := aBlock
+]
 
 { #category : 'icons' }
 MicroUMLAstNode >> addIcon [
@@ -29,6 +45,18 @@ MicroUMLAstNode >> children [
 	^ OrderedCollection empty
 ]
 
+{ #category : 'accessing' }
+MicroUMLAstNode >> comment [
+
+	^ comment
+]
+
+{ #category : 'accessing' }
+MicroUMLAstNode >> comment: aString [
+
+	comment := aString
+]
+
 { #category : 'dialog' }
 MicroUMLAstNode >> confirm: aString [
 
@@ -50,7 +78,7 @@ MicroUMLAstNode >> iconNamed: aSymbol [
 	^ self application iconNamed: aSymbol
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'inspecting' }
 MicroUMLAstNode >> inspectionAST: aBuilder [
 	<inspectorPresentationOrder: 35 title: 'AST'>
 

--- a/src/MicroUML-Builder/ManifestMicroUMLBuilder.class.st
+++ b/src/MicroUML-Builder/ManifestMicroUMLBuilder.class.st
@@ -8,3 +8,10 @@ Class {
 	#package : 'MicroUML-Builder',
 	#tag : 'Manifest'
 }
+
+{ #category : 'code-critics' }
+ManifestMicroUMLBuilder class >> ruleThreeElementPointRuleV1FalsePositive [
+
+	<ignoreForCoverage>
+	^ #(#(#(#RGMethodDefinition #(#'MicroUMLAstBuilder class' #exampleSerie #true)) #'2026-07-09T15:25:17.240565+03:00') #(#(#RGMethodDefinition #(#'MicroUMLAstBuilder class' #exampleSerie2 #true)) #'2026-07-09T15:25:26.141484+03:00') )
+]

--- a/src/MicroUML-Builder/MicroUMLAstBuilder.class.st
+++ b/src/MicroUML-Builder/MicroUMLAstBuilder.class.st
@@ -1,53 +1,64 @@
 "
-I build a UML class diagram.
-I have a namespace of classes to manage class definitions, references and relations among them.
-You can use me explicitly say, like
+# Class Comment for MicroUMLAstBuilder
 
-```MicroUML
-MicroUMLBuilder
-===
-MyClass
-    ++att1@ #int
+## Purpose and Role in the System
+
+The `MicroUMLAstBuilder` class is a critical component within the MicroUML framework, designed to construct abstract syntax trees (ASTs) for UML class diagrams. It serves as a builder that interprets textual descriptions of UML classes and their relationships, transforming them into structured nodes that can be rendered into visual diagrams. This builder is essential for developers who need to generate UML diagrams programmatically or through textual specifications, facilitating the creation of clear and consistent class diagrams without manual drawing.
+
+## Main Collaborators or Dependencies
+
+The `MicroUMLAstBuilder` collaborates closely with several other classes within the MicroUML framework:
+
+- **MicroUMLClassNode**: Represents individual classes in the UML diagram, including their attributes, methods, and modifiers.
+- **MicroUMLAssociationNode**: Represents relationships between classes, such as associations, aggregations, compositions, and dependencies.
+- **MicroUMLClassDiagramNode**: Aggregates class and association nodes to form a complete diagram.
+- **MicroUMLRoassalBuilder**: Utilises the Roassal visualisation engine to render the UML diagram from the AST nodes.
+
+These collaborators work together to ensure that the textual specifications are accurately translated into visual representations.
+
+## Important Invariants or Design Constraints
+
+1. **Class and Association Management**: The builder maintains collections of classes and associations, ensuring that each class and association is uniquely identified and correctly linked.
+2. **Context Awareness**: The builder keeps track of the current class and association being processed, allowing it to apply modifiers and types appropriately.
+3. **Symbol Handling**: The builder handles symbols and strings uniformly, converting them into symbols for consistent processing and storage.
+4. **Error Handling**: The builder includes error handling for cases where invalid inputs are provided, such as non-string or non-class inputs for symbol conversion.
+
+## Illustrative Usage Examples
+
+### Example 1: Creating a Simple Class Diagram
+
+```smalltalk
+builder := MicroUMLAstBuilder new.
+builder === #Person.
+builder - #name @ #String.
+builder - #age @ #Integer.
+builder > #introduce ~ {}.
+builder === #Student.
+builder --|> #Person.
+builder - #studentId @ #String.
+builder > #study ~ {}.
+builder --> #Course.
+builder extent: 600 @ 400.
 ```
-but also imlicit ways, like
-```MicroUML
-#MyClass
-    ++att1 @ #int
+
+This example demonstrates how to create a simple UML diagram with two classes, `Person` and `Student`, where `Student` inherits from `Person` and has a dependency on `Course`.
+
+### Example 2: Creating a Diagram with Associations
+
+```smalltalk
+builder := MicroUMLAstBuilder new.
+builder === #Department.
+builder - #name @ #String.
+builder === #Employee.
+builder - #name @ #String.
+builder - #department @ #Department.
+builder <>-- #Department @ ('employs' -> 'employed by') %< '1..*' %> '1'.
+builder extent: 600 @ 400.
 ```
-or even like
-```MicroUML
-MyClass
-    ++att1 @ #int
-```
-if you actually have a class named `MyClass` in your system.
 
-The following is the summary of how you define a class.
+In this example, an aggregation relationship is established between `Employee` and `Department`, indicating that a department employs multiple employees, and each employee is employed by one department.
 
-```
-""Instance side variables""
-- #var1 ""protected by default""
-- #var2 % #public
-- #var3 % #private
-- #var4 % #protected
-
-""Class side variables""
-|- #var5 ""protected by default""
-|- #var6 % #public
-|- #var7 % #private
-|- #var8 % #protected
-
-""Instance side methods""
-> #method1 ""public by default""
-> #method2 % #public
-> #method3 % #private
-> #method4 % #protected
-
-""Class side methods""
-|> #method5 ""public by default""
-|> #method6 % #public
-|> #method7 % #private
-|> #method8 % #protected
-```
+By following these examples, developers can leverage the `MicroUMLAstBuilder` to create complex UML diagrams with ease, ensuring clarity and consistency in their design documentation.
 "
 Class {
 	#name : 'MicroUMLAstBuilder',
@@ -81,10 +92,12 @@ MicroUMLAstBuilder class >> exampleMicrodown [
 Example of novel and comic derrived from anime
 
 ```pharoscript
-#AbstractSeries 
-	- #name @ String 
-	- #numEpisodes @ Integer % #private
-	> #findByName % #abstract
+MU
+===
+#AbstractSeries // ''the base class of story published in series.''
+	- #name @ String // ''the title of the story''
+	- #numEpisodes @ Integer % #private // ''the number of episodes in the story''
+	> #findByName % #abstract // ''search by name''
 === 
 #NovelSeries 
 	--|> #AbstractSeries
@@ -118,10 +131,12 @@ extent: 600 @ 400
 MicroUMLAstBuilder class >> exampleSerie [
 
 	^ 
-#AbstractSeries 
-	- #name @ String 
-	- #numEpisodes @ Integer % #private
-	> #findByName % #abstract
+MU 
+===
+#AbstractSeries // 'the base class of story published in series.' + [ :ast | ast microUMLSource inspect ]
+	- #name @ String // 'the title of the story'
+	- #numEpisodes @ Integer % #private // 'the number of episodes in the story'
+	> #findByName % #abstract // 'search by name' + [ :ast | ast microUMLSource inspect ]
 === 
 #NovelSeries 
 	--|> #AbstractSeries
@@ -218,6 +233,18 @@ MicroUMLAstBuilder >> *=> aSymbolOrClass [
 		beDirected
 ]
 
+{ #category : 'UML - sapplementals' }
+MicroUMLAstBuilder >> + aBlock [
+
+	currentAssociation
+		ifNil: [
+				currentClass ifNil: [ ] ifNotNil: [
+						currentClass currentMember
+							ifNil: [ self addClassAction: aBlock ]
+							ifNotNil: [ self addMemberAction: aBlock ] ] ]
+		ifNotNil: [ self addAssociationAction: aBlock ]
+]
+
 { #category : 'UML - members' }
 MicroUMLAstBuilder >> - aSymbolOrArray [
 
@@ -246,6 +273,18 @@ MicroUMLAstBuilder >> --@ aSymbolOrClass [
 MicroUMLAstBuilder >> --|> aSymbolOrClass [
 
 	self addSuperclass: (self getSymbol: aSymbolOrClass)
+]
+
+{ #category : 'UML - sapplementals' }
+MicroUMLAstBuilder >> // aString [
+
+	currentAssociation
+		ifNil: [
+				currentClass ifNil: [ ] ifNotNil: [
+						currentClass currentMember
+							ifNil: [ self addClassComment: aString ]
+							ifNotNil: [ self addMemberComment: aString ] ] ]
+		ifNotNil: [ self addAssociationComment: aString ]
 ]
 
 { #category : 'UML - associations' }
@@ -304,6 +343,12 @@ MicroUMLAstBuilder >> @= aSymbolOrClass [
 	self addAssociationClass: (self getSymbol: aSymbolOrClass)
 ]
 
+{ #category : 'building - supplementals' }
+MicroUMLAstBuilder >> addAssociationAction: aBlock [
+
+	currentAssociation actionBlock: aBlock
+]
+
 { #category : 'building - associations' }
 MicroUMLAstBuilder >> addAssociationClass: aSymbol [
 
@@ -311,10 +356,28 @@ MicroUMLAstBuilder >> addAssociationClass: aSymbol [
 		(self ensureClassAt: aSymbol) name
 ]
 
+{ #category : 'building - supplementals' }
+MicroUMLAstBuilder >> addAssociationComment: aString [
+
+	currentAssociation comment: aString
+]
+
 { #category : 'building - associations' }
 MicroUMLAstBuilder >> addAssociationLabel: aStringOrAssociation [
 
 	currentAssociation addLabel: aStringOrAssociation
+]
+
+{ #category : 'building - supplementals' }
+MicroUMLAstBuilder >> addClassAction: aBlock [
+
+	currentClass actionBlock: aBlock
+]
+
+{ #category : 'building - supplementals' }
+MicroUMLAstBuilder >> addClassComment: aString [
+
+	currentClass comment: aString
 ]
 
 { #category : 'building - classes' }
@@ -327,6 +390,18 @@ MicroUMLAstBuilder >> addClassModifier: aSymbol [
 MicroUMLAstBuilder >> addLeftMultiplicity: aString [
 
 	currentAssociation leftMultiplicity: aString
+]
+
+{ #category : 'building - supplementals' }
+MicroUMLAstBuilder >> addMemberAction: aBlock [
+
+	currentClass currentMember actionBlock: aBlock
+]
+
+{ #category : 'building - supplementals' }
+MicroUMLAstBuilder >> addMemberComment: aString [
+
+	currentClass currentMember comment: aString
 ]
 
 { #category : 'building - members' }

--- a/src/MicroUML-Builder/MicroUMLRoassalBuilder.class.st
+++ b/src/MicroUML-Builder/MicroUMLRoassalBuilder.class.st
@@ -8,7 +8,8 @@ Class {
 	#instVars : [
 		'classDiagramNode',
 		'nodes',
-		'colorBlock'
+		'colorBlock',
+		'interaction'
 	],
 	#category : 'MicroUML-Builder',
 	#package : 'MicroUML-Builder'
@@ -44,6 +45,105 @@ MicroUMLRoassalBuilder class >> exampleSerie2 [
 MicroUMLRoassalBuilder >> associationEdgeColor [
 
 	^ Color lightGray
+]
+
+{ #category : 'private' }
+MicroUMLRoassalBuilder >> attachInteraction: aRSShape [
+
+	aRSShape model ifNotNil: [ :model |
+			(model comment notNil or: [ model actionBlock notNil ]) ifTrue: [
+				aRSShape @ interaction ] ]
+]
+
+{ #category : 'instance creation' }
+MicroUMLRoassalBuilder >> basicNewClassBoxFor: aMicroUMLClassNode [
+
+	| color myLabel attributeShapes methodShapes memberShapes rect y1 y2 |
+	color := self colorFor: aMicroUMLClassNode.
+	myLabel := Array streamContents: [ :stream |
+			           | label |
+			           aMicroUMLClassNode keywordsDo: [ :keyword |
+					           stream nextPut: (RSLabel new
+							            text: '<<' , keyword , '>>';
+							            color: Color darkGray) ].
+			           label := RSLabel new
+				                    text: aMicroUMLClassNode name;
+				                    color: color.
+			           aMicroUMLClassNode isAbstract ifTrue: [ label italic ].
+			           stream nextPut: label ].
+	RSVerticalLineLayout new
+		alignCenter;
+		on: myLabel.
+	myLabel := myLabel asShape.
+	myLabel extent x < 100 ifTrue: [
+		myLabel extent: 100 @ myLabel extent y ].
+	aMicroUMLClassNode isEmptyDefinition
+		ifTrue: [
+				^ {
+					  (RSBox new
+						   extent: myLabel extent + (10 @ 6);
+						   position: myLabel position;
+						   color: Color white;
+						   borderColor: color;
+						   borderWidth: 1).
+					  myLabel } asShapeFor: aMicroUMLClassNode ]
+		ifFalse: [
+				attributeShapes := aMicroUMLClassNode attributesCollect: [
+					                   :attribute |
+					                   self newMemberLabelFor: attribute ].
+				RSVerticalLineLayout new
+					alignLeft;
+					on: attributeShapes.
+				attributeShapes := attributeShapes asShape.
+
+
+				methodShapes := aMicroUMLClassNode methodsCollect: [ :method |
+					                self newMemberLabelFor: method ].
+				RSVerticalLineLayout new
+					alignLeft;
+					on: methodShapes.
+				methodShapes := methodShapes asShape.
+
+				RSVerticalLineLayout new
+					alignLeft;
+					gapSize: 10;
+					on: {
+							attributeShapes.
+							methodShapes }.
+				memberShapes := {
+					                attributeShapes.
+					                methodShapes } asShape.
+
+				myLabel extent x < memberShapes extent x ifTrue: [
+					myLabel extent: memberShapes extent x @ myLabel extent y ].
+				RSVerticalLineLayout new
+					alignLeft;
+					gapSize: 10;
+					on: {
+							myLabel.
+							memberShapes }.
+				rect := {
+					        myLabel.
+					        memberShapes } asShape encompassingRectangle.
+				y1 := myLabel encompassingRectangle bottom + 5.
+				y2 := y1 + attributeShapes encompassingRectangle height + 10.
+
+				^ {
+					  (RSBox new
+						   extent: rect extent + (10 @ 6);
+						   color: Color white;
+						   borderColor: color;
+						   borderWidth: 1).
+					  (RSLine new
+						   startPoint: rect extent x / -2 - 5 @ y1;
+						   endPoint: rect extent x / 2 + 5 @ y1;
+						   color: color).
+					  (RSLine new
+						   startPoint: rect extent x / -2 - 5 @ y2;
+						   endPoint: rect extent x / 2 + 5 @ y2;
+						   color: color).
+					  myLabel.
+					  memberShapes } asShapeFor: aMicroUMLClassNode ]
 ]
 
 { #category : 'accessing' }
@@ -100,97 +200,17 @@ MicroUMLRoassalBuilder >> inheritanceEdgeColor [
 MicroUMLRoassalBuilder >> initialize [
 
 	super initialize.
-	nodes := Dictionary new
+	nodes := Dictionary new.
+	interaction := MicroUMLRoassalInteraction new
 ]
 
 { #category : 'instance creation' }
 MicroUMLRoassalBuilder >> newClassBoxFor: aMicroUMLClassNode [
 
-	| color myLabel attributeShapes methodShapes memberShapes rect y1 y2 |
-	color := self colorFor: aMicroUMLClassNode.
-	myLabel := Array streamContents: [ :stream |
-			           | label |
-			           aMicroUMLClassNode keywordsDo: [ :keyword |
-					           stream nextPut: (RSLabel new
-							            text: '<<' , keyword , '>>';
-							            color: Color darkGray) ].
-			           label := RSLabel new
-				                    text: aMicroUMLClassNode name;
-				                    color: color.
-			           aMicroUMLClassNode isAbstract ifTrue: [ label italic ].
-			           stream nextPut: label ].
-	RSVerticalLineLayout new
-		alignCenter;
-		on: myLabel.
-	myLabel := myLabel asShape.
-	myLabel extent x < 100 ifTrue: [
-		myLabel extent: 100 @ myLabel extent y ].
-	aMicroUMLClassNode isEmptyDefinition
-		ifTrue: [
-				^ {
-					  (RSBox new
-						   extent: myLabel extent + (10 @ 6);
-						   position: myLabel position;
-						   color: Color white;
-						   borderColor: color;
-						   borderWidth: 1).
-					  myLabel } asShapeFor: aMicroUMLClassNode ]
-		ifFalse: [
-				attributeShapes := aMicroUMLClassNode attributesCollect: [
-					                   :attribute |
-					                   self newMemberLabelFor: attribute ].
-				RSVerticalLineLayout new
-					alignLeft;
-					on: attributeShapes.
-				attributeShapes := attributeShapes asShape.
-
-				methodShapes := aMicroUMLClassNode methodsCollect: [ :method |
-					                self newMemberLabelFor: method ].
-				RSVerticalLineLayout new
-					alignLeft;
-					on: methodShapes.
-				methodShapes := methodShapes asShape.
-
-				RSVerticalLineLayout new
-					alignLeft;
-					gapSize: 10;
-					on: {
-							attributeShapes.
-							methodShapes }.
-				memberShapes := {
-					                attributeShapes.
-					                methodShapes } asShape.
-
-				myLabel extent x < memberShapes extent x ifTrue: [
-					myLabel extent: memberShapes extent x @ myLabel extent y ].
-				RSVerticalLineLayout new
-					alignLeft;
-					gapSize: 10;
-					on: {
-							myLabel.
-							memberShapes }.
-				rect := {
-					        myLabel.
-					        memberShapes } asShape encompassingRectangle.
-				y1 := myLabel encompassingRectangle bottom + 5.
-				y2 := y1 + attributeShapes encompassingRectangle height + 10.
-
-				^ {
-					  (RSBox new
-						   extent: rect extent + (10 @ 6);
-						   color: Color white;
-						   borderColor: color;
-						   borderWidth: 1).
-					  (RSLine new
-						   startPoint: rect extent x / -2 - 5 @ y1;
-						   endPoint: rect extent x / 2 + 5 @ y1;
-						   color: color).
-					  (RSLine new
-						   startPoint: rect extent x / -2 - 5 @ y2;
-						   endPoint: rect extent x / 2 + 5 @ y2;
-						   color: color).
-					  myLabel.
-					  memberShapes } asShapeFor: aMicroUMLClassNode ]
+	| box |
+	box := self basicNewClassBoxFor: aMicroUMLClassNode.
+	self attachInteraction: box.
+	^ box
 ]
 
 { #category : 'instance creation' }
@@ -206,6 +226,7 @@ MicroUMLRoassalBuilder >> newEdgeFor: aMicroUMLAssociationNode [
 			          (self newMarkerFor: aMicroUMLAssociationNode rightHead);
 		          yourself.
 	aMicroUMLAssociationNode line = #dashed ifTrue: [ bazier dashed ].
+	self attachInteraction: bazier.
 	^ bazier
 ]
 
@@ -305,6 +326,7 @@ MicroUMLRoassalBuilder >> newMemberLabelFor: aMicroUMLMemberNode [
 		label emphasis: TextEmphasis italic ].
 	aMicroUMLMemberNode isClassSide ifTrue: [
 		label emphasis: TextEmphasis underlined ].
+	self attachInteraction: label.
 	^ label
 ]
 

--- a/src/MicroUML-Builder/MicroUMLRoassalInteraction.class.st
+++ b/src/MicroUML-Builder/MicroUMLRoassalInteraction.class.st
@@ -1,0 +1,501 @@
+Class {
+	#name : 'MicroUMLRoassalInteraction',
+	#superclass : 'RSInteraction',
+	#instVars : [
+		'shape',
+		'box'
+	],
+	#category : 'MicroUML-Builder',
+	#package : 'MicroUML-Builder'
+}
+
+{ #category : 'menus' }
+MicroUMLRoassalInteraction >> contextMenuFor: aRSShape [
+
+	aRSShape model ifNotNil: [ :model |
+			(model isKindOf: MicroUMLClassNode) ifTrue: [
+				^ self contextMenuForClassNode: model ].
+			(model isKindOf: MicroUMLAttributeNode) ifTrue: [
+				^ self contextMenuForAttributeNode: model ].
+			(model isKindOf: MicroUMLMethodNode) ifTrue: [
+				^ self contextMenuForMethodNode: model ].
+			(model isKindOf: MicroUMLAssociationNode) ifTrue: [
+				^ self contextMenuForAssociationNode: model ] ].
+	^ nil
+]
+
+{ #category : 'menus' }
+MicroUMLRoassalInteraction >> contextMenuForAssociationNode: aMicroUMLAssociationNode [
+
+	^ SpMenuPresenter new
+		  title: aMicroUMLAssociationNode leftClass , ' - '
+			  , aMicroUMLAssociationNode rightClass;
+		  addGroup: [ :group |
+				  group addItem: [ :item |
+							  item
+								  name: 'Remove';
+								  icon: aMicroUMLAssociationNode removeIcon;
+								  action: [ aMicroUMLAssociationNode remove ] ] ];
+		  addGroup: [ :group |
+				  aMicroUMLAssociationNode isAggregation ifFalse: [
+						  group addItem: [ :item |
+								  item
+									  name: 'Be aggregation';
+									  action: [
+											  aMicroUMLAssociationNode
+												  beAggregation;
+												  announceDiagramChange ] ] ].
+				  aMicroUMLAssociationNode isComposition ifFalse: [
+						  group addItem: [ :item |
+								  item
+									  name: 'Be composition';
+									  action: [
+											  aMicroUMLAssociationNode
+												  beComposition;
+												  announceDiagramChange ] ] ].
+				  aMicroUMLAssociationNode isNoAggregation ifFalse: [
+						  group addItem: [ :item |
+								  item
+									  name: 'Be non-aggregation';
+									  action: [
+											  aMicroUMLAssociationNode
+												  beNoAggregation;
+												  announceDiagramChange ] ] ].
+				  aMicroUMLAssociationNode isDependency ifFalse: [
+						  group addItem: [ :item |
+								  item
+									  name: 'Be dependency';
+									  action: [
+											  aMicroUMLAssociationNode
+												  beDependency;
+												  announceDiagramChange ] ] ].
+				  aMicroUMLAssociationNode isDirected
+					  ifTrue: [
+							  group addItem: [ :item |
+									  item
+										  name: 'Be not directed';
+										  action: [
+												  aMicroUMLAssociationNode
+													  beNotDirected;
+													  announceDiagramChange ] ] ]
+					  ifFalse: [
+							  group addItem: [ :item |
+									  item
+										  name: 'Be directed';
+										  action: [
+												  aMicroUMLAssociationNode
+													  beDirected;
+													  announceDiagramChange ] ] ].
+				  aMicroUMLAssociationNode isSolid ifFalse: [
+						  group addItem: [ :item |
+								  item
+									  name: 'Be solid line';
+									  action: [
+											  aMicroUMLAssociationNode
+												  beSolid;
+												  announceDiagramChange ] ] ].
+				  aMicroUMLAssociationNode isDashed ifFalse: [
+						  group addItem: [ :item |
+								  item
+									  name: 'Be dashed line';
+									  action: [
+											  aMicroUMLAssociationNode
+												  beDashed;
+												  announceDiagramChange ] ] ] ];
+		  addGroup: [ :group |
+				  group
+					  addItem: [ :item |
+							  item
+								  name: aMicroUMLAssociationNode leftClass;
+								  subMenu: aMicroUMLAssociationNode contextMenuOnLeft ];
+					  addItem: [ :item |
+							  item
+								  name: aMicroUMLAssociationNode rightClass;
+								  subMenu: aMicroUMLAssociationNode contextMenuOnRight ];
+					  addItem: [ :item |
+							  item
+								  name: 'Change label...';
+								  action: [ aMicroUMLAssociationNode changeLabel ] ] ];
+		  yourself
+]
+
+{ #category : 'menus' }
+MicroUMLRoassalInteraction >> contextMenuForAttributeNode: aMicroUMLAttributeNode [
+
+	^ SpMenuPresenter new
+		  title: aMicroUMLAttributeNode name;
+		  addGroup: [ :group |
+				  group
+					  addItem: [ :item |
+							  item
+								  name: 'Rename...';
+								  action: [ aMicroUMLAttributeNode rename ] ];
+					  addItem: [ :item |
+							  item
+								  name: 'Remove';
+								  icon: aMicroUMLAttributeNode removeIcon;
+								  action: [ aMicroUMLAttributeNode remove ] ] ];
+		  addGroup: [ :group |
+				  aMicroUMLAttributeNode isPublic ifFalse: [
+						  group addItem: [ :item |
+								  item
+									  name: 'Be public';
+									  action: [
+											  aMicroUMLAttributeNode bePublic.
+											  aMicroUMLAttributeNode announceDiagramChange ] ] ].
+				  aMicroUMLAttributeNode isProtected ifFalse: [
+						  group addItem: [ :item |
+								  item
+									  name: 'Be protected';
+									  action: [
+											  aMicroUMLAttributeNode beProtected.
+											  aMicroUMLAttributeNode announceDiagramChange ] ] ].
+				  aMicroUMLAttributeNode isPrivate ifFalse: [
+						  group addItem: [ :item |
+								  item
+									  name: 'Be private';
+									  action: [
+											  aMicroUMLAttributeNode bePrivate.
+											  aMicroUMLAttributeNode announceDiagramChange ] ] ].
+				  group
+					  addItem: [ :item |
+							  aMicroUMLAttributeNode isAbstract
+								  ifTrue: [
+										  item
+											  name: 'Be implementation';
+											  action: [
+													  aMicroUMLAttributeNode beConcrete.
+													  aMicroUMLAttributeNode announceDiagramChange ] ]
+								  ifFalse: [
+										  item
+											  name: 'Be abstract';
+											  action: [
+													  aMicroUMLAttributeNode beAbstract.
+													  aMicroUMLAttributeNode announceDiagramChange ] ] ];
+					  addItem: [ :item |
+							  aMicroUMLAttributeNode isClassSide
+								  ifTrue: [
+										  item
+											  name: 'Be instance side';
+											  action: [
+													  aMicroUMLAttributeNode beInstanceSide.
+													  aMicroUMLAttributeNode announceDiagramChange ] ]
+								  ifFalse: [
+										  item
+											  name: 'Be class side';
+											  action: [
+													  aMicroUMLAttributeNode beClassSide.
+													  aMicroUMLAttributeNode announceDiagramChange ] ] ] ];
+		  addGroup: [ :group |
+				  group addItem: [ :item |
+						  item
+							  name: 'Change type...';
+							  action: [ aMicroUMLAttributeNode changeType ] ] ];
+		  yourself
+]
+
+{ #category : 'menus' }
+MicroUMLRoassalInteraction >> contextMenuForClassNode: aMicroUMLClassNode [
+
+	^ SpMenuPresenter new
+		  title: aMicroUMLClassNode name;
+		  addGroup: [ :group |
+				  group
+					  addItem: [ :item |
+							  item
+								  name: 'Rename...';
+								  action: [ aMicroUMLClassNode rename ] ];
+					  addItem: [ :item |
+							  item
+								  name: 'Remove';
+								  icon: aMicroUMLClassNode removeIcon;
+								  action: [ aMicroUMLClassNode remove ] ].
+				  (Smalltalk classNamed: aMicroUMLClassNode name) ifNotNil: [
+						  :class |
+						  group addItem: [ :item |
+								  item
+									  name: 'Browse...';
+									  iconName: #browse;
+									  action: [ class browse ] ] ] ];
+		  addGroup: [ :group |
+				  group
+					  addItem: [ :item |
+							  aMicroUMLClassNode isAbstract
+								  ifTrue: [
+										  item
+											  name: 'Be concrete';
+											  action: [
+													  aMicroUMLClassNode beConcrete.
+													  aMicroUMLClassNode announceDiagramChange ] ]
+								  ifFalse: [
+										  item
+											  name: 'Be abstract';
+											  action: [
+													  aMicroUMLClassNode beAbstract.
+													  aMicroUMLClassNode announceDiagramChange ] ] ];
+					  addItem: [ :item |
+							  aMicroUMLClassNode isClass
+								  ifTrue: [
+										  item
+											  name: 'Be trait';
+											  action: [
+													  aMicroUMLClassNode beTrait.
+													  aMicroUMLClassNode announceDiagramChange ] ]
+								  ifFalse: [
+										  item
+											  name: 'Be class';
+											  action: [
+													  aMicroUMLClassNode beClass.
+													  aMicroUMLClassNode announceDiagramChange ] ] ] ];
+		  addGroup: [ :group |
+				  group addItem: [ :item |
+						  item
+							  name: 'Superclass...';
+							  action: [ aMicroUMLClassNode changeSuperclass ] ] ];
+		  addGroup: [ :group |
+				  group
+					  addItem: [ :item |
+							  | traitMenu |
+							  traitMenu := SpMenuPresenter new.
+							  traitMenu addItem: [ :addTraitItem |
+										  addTraitItem
+											  name: 'Add trait...';
+											  icon: aMicroUMLClassNode addIcon;
+											  action: [ aMicroUMLClassNode addTrait ] ].
+							  aMicroUMLClassNode traits do: [ :traitName |
+									  traitMenu addItem: [ :removeTraitItem |
+											  removeTraitItem
+												  name: 'Remove ' , traitName;
+												  icon: aMicroUMLClassNode removeIcon;
+												  action: [ aMicroUMLClassNode removeTrait: traitName ] ] ].
+							  item
+								  name: 'Traits';
+								  subMenu: traitMenu ];
+					  addItem: [ :item |
+							  | attributeMenu |
+							  attributeMenu := SpMenuPresenter new.
+							  attributeMenu addItem: [ :addAttributeItem |
+									  addAttributeItem
+										  name: 'Add attribute...';
+										  icon: aMicroUMLClassNode addIcon;
+										  action: [ aMicroUMLClassNode addAttribute ] ].
+							  aMicroUMLClassNode attributesDo: [ :attributeNode |
+									  attributeMenu addItem: [ :attributeNodeMenu |
+											  attributeNodeMenu
+												  name: attributeNode name;
+												  subMenu:
+													  (self contextMenuForAttributeNode: attributeNode) ] ].
+							  item
+								  name: 'Attributes';
+								  subMenu: attributeMenu ];
+					  addItem: [ :item |
+							  | methodMenu |
+							  methodMenu := SpMenuPresenter new.
+							  methodMenu addItem: [ :addMethodItem |
+									  addMethodItem
+										  name: 'Add method...';
+										  icon: aMicroUMLClassNode addIcon;
+										  action: [ aMicroUMLClassNode addMethod ] ].
+
+							  aMicroUMLClassNode methodsDo: [ :methodNode |
+									  methodMenu addItem: [ :attributeNodeMenu |
+											  attributeNodeMenu
+												  name: methodNode name;
+												  subMenu: (self contextMenuForMethodNode: methodNode) ] ].
+							  item
+								  name: 'Methods';
+								  subMenu: methodMenu ];
+					  addItem: [ :item |
+							  | associationMenu |
+							  associationMenu := SpMenuPresenter new.
+							  aMicroUMLClassNode diagram ifNotNil: [ :diagram |
+									  associationMenu addItem: [ :addAssociationItem |
+											  | addAssociationMenu |
+											  addAssociationMenu := SpMenuPresenter new.
+											  diagram classesDo: [ :classNode |
+													  classNode ~~ aMicroUMLClassNode ifTrue: [
+															  addAssociationMenu addItem: [
+																	  :addAssociationClassItem |
+																	  addAssociationClassItem
+																		  name: classNode name;
+																		  action: [
+																				  aMicroUMLClassNode addAssociation:
+																						  classNode name.
+																				  aMicroUMLClassNode announceDiagramChange ] ] ] ].
+											  addAssociationItem
+												  name: 'Add association with';
+												  icon: aMicroUMLClassNode addIcon;
+												  subMenu: addAssociationMenu ].
+									  diagram associationsDo: [ :associationNode |
+											  associationNode leftClass = aMicroUMLClassNode name
+												  ifTrue: [
+														  associationMenu addItem: [ :associationNodeMenu |
+																  associationNodeMenu
+																	  name: 'with ' , associationNode rightClass;
+																	  subMenu:
+																		  (self contextMenuForAssociationNode:
+																				   associationNode) ] ].
+											  associationNode rightClass = aMicroUMLClassNode name
+												  ifTrue: [
+														  associationMenu addItem: [ :attributeNodeMenu |
+																  attributeNodeMenu
+																	  name: 'with ' , associationNode leftClass;
+																	  subMenu:
+																		  (self contextMenuForAssociationNode:
+																				   associationNode) ] ] ] ].
+							  item
+								  name: 'Associations';
+								  subMenu: associationMenu ] ];
+		  yourself
+]
+
+{ #category : 'menus' }
+MicroUMLRoassalInteraction >> contextMenuForMethodNode: aMicroUMLMethodNode [
+
+	^ SpMenuPresenter new
+		  title: aMicroUMLMethodNode name;
+		  addGroup: [ :group |
+				  group
+					  addItem: [ :item |
+							  item
+								  name: 'Rename...';
+								  action: [ aMicroUMLMethodNode rename ] ];
+					  addItem: [ :item |
+							  item
+								  name: 'Remove';
+								  icon: aMicroUMLMethodNode removeIcon;
+								  action: [ aMicroUMLMethodNode remove ] ].
+				  (Smalltalk classNamed:
+					   (aMicroUMLMethodNode classNode ifNotNil: #name)) ifNotNil: [
+						  :class |
+						  class
+							  compiledMethodAt: aMicroUMLMethodNode name
+							  ifPresent: [ :method |
+									  group addItem: [ :item |
+											  item
+												  name: 'Browse...';
+												  iconName: #browse;
+												  action: [ method browse ] ] ] ] ];
+		  addGroup: [ :group |
+				  aMicroUMLMethodNode isPublic ifFalse: [
+						  group addItem: [ :item |
+								  item
+									  name: 'Be public';
+									  action: [
+											  aMicroUMLMethodNode bePublic.
+											  aMicroUMLMethodNode announceDiagramChange ] ] ].
+				  aMicroUMLMethodNode isProtected ifFalse: [
+						  group addItem: [ :item |
+								  item
+									  name: 'Be protected';
+									  action: [
+											  aMicroUMLMethodNode beProtected.
+											  aMicroUMLMethodNode announceDiagramChange ] ] ].
+				  aMicroUMLMethodNode isPrivate ifFalse: [
+						  group addItem: [ :item |
+								  item
+									  name: 'Be private';
+									  action: [
+											  aMicroUMLMethodNode bePrivate.
+											  aMicroUMLMethodNode announceDiagramChange ] ] ].
+				  group
+					  addItem: [ :item |
+							  aMicroUMLMethodNode isAbstract
+								  ifTrue: [
+										  item
+											  name: 'Be implementation';
+											  action: [
+													  aMicroUMLMethodNode beConcrete.
+													  aMicroUMLMethodNode announceDiagramChange ] ]
+								  ifFalse: [
+										  item
+											  name: 'Be abstract';
+											  action: [
+													  aMicroUMLMethodNode beAbstract.
+													  aMicroUMLMethodNode announceDiagramChange ] ] ];
+					  addItem: [ :item |
+							  aMicroUMLMethodNode isClassSide
+								  ifTrue: [
+										  item
+											  name: 'Be instance side';
+											  action: [
+													  aMicroUMLMethodNode beInstanceSide.
+													  aMicroUMLMethodNode announceDiagramChange ] ]
+								  ifFalse: [
+										  item
+											  name: 'Be class side';
+											  action: [
+													  aMicroUMLMethodNode beClassSide.
+													  aMicroUMLMethodNode announceDiagramChange ] ] ] ];
+		  addGroup: [ :group |
+				  group
+					  addItem: [ :item |
+							  item
+								  name: 'Change argument type...';
+								  action: [ aMicroUMLMethodNode changeArgumentTypes ] ];
+					  addItem: [ :item |
+							  item
+								  name: 'Change return type...';
+								  action: [ aMicroUMLMethodNode changeType ] ] ];
+		  yourself
+]
+
+{ #category : 'event handling' }
+MicroUMLRoassalInteraction >> mouseClick: event [
+
+	event shape model ifNotNil: [ :model |
+		model actionBlock ifNotNil: [ :action | action cull: model ] ]
+]
+
+{ #category : 'event handling' }
+MicroUMLRoassalInteraction >> mouseEnter: event [
+
+	(box notNil and: [ shape == event shape ]) ifTrue: [ ^ self ].
+	shape := event shape.
+	box ifNotNil: #remove.
+	box := nil.
+	event shape model ifNotNil: [ :node |
+			node comment ifNotNil: [ :comment |
+					| label |
+					label := RSLabel new
+						         text: comment;
+						         color: Color black;
+						         yourself.
+					box := (RSGroup new
+						        add: (RSBox new
+								         color: Color white;
+								         fromRectangle:
+									         (label encompassingRectangle expandBy: 4);
+								         border: (RSBorder new
+										          width: 2;
+										          color: Color black));
+						        add: label;
+						        yourself) asShape.
+					box translateTo:
+						event positionFromCamera
+						+ (box encompassingRectangle right + 10 @ 0).
+					event canvas addShape: box.
+					event canvas signalUpdate ] ]
+]
+
+{ #category : 'event handling' }
+MicroUMLRoassalInteraction >> mouseLeave: event [
+
+	(shape notNil and: [
+		 shape encompassingRectangle containsPoint: event positionFromCamera ])
+		ifTrue: [ ^ self ].
+	box ifNotNil: #remove.
+	box := nil.
+	shape := nil.
+	event canvas signalUpdate
+]
+
+{ #category : 'hooks' }
+MicroUMLRoassalInteraction >> onShape: aShape [
+	"opens my context menu with a right click."
+
+	aShape
+		when: RSMouseClick do: [ :evt | self mouseClick: evt ] for: self;
+		when: RSMouseLeave do: [ :evt | self mouseLeave: evt ] for: self;
+		when: RSMouseEnter do: [ :evt | self mouseEnter: evt ] for: self
+]

--- a/src/MicroUML-Builder/MicroUMLRoassalInteraction.class.st
+++ b/src/MicroUML-Builder/MicroUMLRoassalInteraction.class.st
@@ -3,7 +3,7 @@ Class {
 	#superclass : 'RSInteraction',
 	#instVars : [
 		'shape',
-		'box'
+		'commentBox'
 	],
 	#category : 'MicroUML-Builder',
 	#package : 'MicroUML-Builder'
@@ -450,10 +450,10 @@ MicroUMLRoassalInteraction >> mouseClick: event [
 { #category : 'event handling' }
 MicroUMLRoassalInteraction >> mouseEnter: event [
 
-	(box notNil and: [ shape == event shape ]) ifTrue: [ ^ self ].
+	(commentBox notNil and: [ shape == event shape ]) ifTrue: [ ^ self ].
 	shape := event shape.
-	box ifNotNil: #remove.
-	box := nil.
+	commentBox ifNotNil: #remove.
+	commentBox := nil.
 	event shape model ifNotNil: [ :node |
 			node comment ifNotNil: [ :comment |
 					| label |
@@ -461,7 +461,7 @@ MicroUMLRoassalInteraction >> mouseEnter: event [
 						         text: comment;
 						         color: Color black;
 						         yourself.
-					box := (RSGroup new
+					commentBox := (RSGroup new
 						        add: (RSBox new
 								         color: Color white;
 								         fromRectangle:
@@ -471,10 +471,10 @@ MicroUMLRoassalInteraction >> mouseEnter: event [
 										          color: Color black));
 						        add: label;
 						        yourself) asShape.
-					box translateTo:
+					commentBox translateTo:
 						event positionFromCamera
-						+ (box encompassingRectangle right + 10 @ 0).
-					event canvas addShape: box.
+						+ (commentBox encompassingRectangle right + 10 @ 0).
+					event canvas addShape: commentBox.
 					event canvas signalUpdate ] ]
 ]
 
@@ -484,8 +484,8 @@ MicroUMLRoassalInteraction >> mouseLeave: event [
 	(shape notNil and: [
 		 shape encompassingRectangle containsPoint: event positionFromCamera ])
 		ifTrue: [ ^ self ].
-	box ifNotNil: #remove.
-	box := nil.
+	commentBox ifNotNil: #remove.
+	commentBox := nil.
 	shape := nil.
 	event canvas signalUpdate
 ]

--- a/src/MicroUML-Editor/MicroUMLBrowserNodeInteraction.class.st
+++ b/src/MicroUML-Editor/MicroUMLBrowserNodeInteraction.class.st
@@ -454,7 +454,7 @@ MicroUMLBrowserNodeInteraction >> mouseEnter: event [
 				       width: 5;
 				       color: UITheme current selectionColor;
 				       yourself.
-			event shape parent add: box.
+			event shape parent add: box; pushBack: box.
 			event canvas signalUpdate ]
 ]
 

--- a/src/MicroUML-Editor/MicroUMLBrowserNodeInteraction.class.st
+++ b/src/MicroUML-Editor/MicroUMLBrowserNodeInteraction.class.st
@@ -1,5 +1,5 @@
 Class {
-	#name : 'MicroUMLAstNodeInteraction',
+	#name : 'MicroUMLBrowserNodeInteraction',
 	#superclass : 'RSInteraction',
 	#instVars : [
 		'box'
@@ -9,7 +9,7 @@ Class {
 }
 
 { #category : 'menus' }
-MicroUMLAstNodeInteraction >> contextMenuFor: aRSShape [
+MicroUMLBrowserNodeInteraction >> contextMenuFor: aRSShape [
 
 	aRSShape model ifNotNil: [ :model |
 			(model isKindOf: MicroUMLClassNode) ifTrue: [
@@ -24,7 +24,7 @@ MicroUMLAstNodeInteraction >> contextMenuFor: aRSShape [
 ]
 
 { #category : 'menus' }
-MicroUMLAstNodeInteraction >> contextMenuForAssociationNode: aMicroUMLAssociationNode [
+MicroUMLBrowserNodeInteraction >> contextMenuForAssociationNode: aMicroUMLAssociationNode [
 
 	^ SpMenuPresenter new
 		  title: aMicroUMLAssociationNode leftClass , ' - '
@@ -119,7 +119,7 @@ MicroUMLAstNodeInteraction >> contextMenuForAssociationNode: aMicroUMLAssociatio
 ]
 
 { #category : 'menus' }
-MicroUMLAstNodeInteraction >> contextMenuForAttributeNode: aMicroUMLAttributeNode [
+MicroUMLBrowserNodeInteraction >> contextMenuForAttributeNode: aMicroUMLAttributeNode [
 
 	^ SpMenuPresenter new
 		  title: aMicroUMLAttributeNode name;
@@ -194,7 +194,7 @@ MicroUMLAstNodeInteraction >> contextMenuForAttributeNode: aMicroUMLAttributeNod
 ]
 
 { #category : 'menus' }
-MicroUMLAstNodeInteraction >> contextMenuForClassNode: aMicroUMLClassNode [
+MicroUMLBrowserNodeInteraction >> contextMenuForClassNode: aMicroUMLClassNode [
 
 	^ SpMenuPresenter new
 		  title: aMicroUMLClassNode name;
@@ -349,7 +349,7 @@ MicroUMLAstNodeInteraction >> contextMenuForClassNode: aMicroUMLClassNode [
 ]
 
 { #category : 'menus' }
-MicroUMLAstNodeInteraction >> contextMenuForMethodNode: aMicroUMLMethodNode [
+MicroUMLBrowserNodeInteraction >> contextMenuForMethodNode: aMicroUMLMethodNode [
 
 	^ SpMenuPresenter new
 		  title: aMicroUMLMethodNode name;
@@ -440,7 +440,7 @@ MicroUMLAstNodeInteraction >> contextMenuForMethodNode: aMicroUMLMethodNode [
 ]
 
 { #category : 'event handling' }
-MicroUMLAstNodeInteraction >> mouseEnter: event [
+MicroUMLBrowserNodeInteraction >> mouseEnter: event [
 
 	event shape encompassingRectangle ifNotNil: [ :rect |
 			box ifNotNil: #remove.
@@ -459,7 +459,7 @@ MicroUMLAstNodeInteraction >> mouseEnter: event [
 ]
 
 { #category : 'event handling' }
-MicroUMLAstNodeInteraction >> mouseLeave: event [
+MicroUMLBrowserNodeInteraction >> mouseLeave: event [
 
 	box ifNotNil: #remove.
 	box := nil.
@@ -467,7 +467,7 @@ MicroUMLAstNodeInteraction >> mouseLeave: event [
 ]
 
 { #category : 'hooks' }
-MicroUMLAstNodeInteraction >> onShape: aShape [
+MicroUMLBrowserNodeInteraction >> onShape: aShape [
 	"opens my context menu with a right click."
 
 	aShape

--- a/src/MicroUML-Editor/MicroUMLEditor.class.st
+++ b/src/MicroUML-Editor/MicroUMLEditor.class.st
@@ -114,7 +114,7 @@ MicroUMLEditor >> drawDiagram [
 	builder classDiagramNode: diagram.
 	builder canvas shapes copy do: [ :shape | shape remove ].
 	builder build.
-	astNodeInteraction := MicroUMLAstNodeInteraction new.
+	astNodeInteraction := MicroUMLBrowserNodeInteraction new.
 	builder canvas allChildren do: [ :shape |
 		shape model isMicroUMLAstNode ifTrue: [ shape @ astNodeInteraction ] ].
 	builder canvas @ MicroUMLCanvasController.


### PR DESCRIPTION
The AST builder now accepts two new operatorsː `+` and `//`.
The `+` operator takes a block as an argument that adds an action when the AST node is clicked on Roassal.
The block can be zero argument or one argument (the AST node object will be given).
The `//` operator takes a comment string, which will hover when the mouse enters into the node on Roassal.