### PR TITLE
enable `<` and `>` in MicroUML editor.

### DIFF
--- a/src/MicroUML-Editor/MicroUMLBrowser.class.st
+++ b/src/MicroUML-Editor/MicroUMLBrowser.class.st
@@ -10,8 +10,9 @@ Class {
 		'showsCode',
 		'showsPreview'
 	],
-	#category : 'MicroUML-Editor',
-	#package : 'MicroUML-Editor'
+	#category : 'MicroUML-Editor-Spec2',
+	#package : 'MicroUML-Editor',
+	#tag : 'Spec2'
 }
 
 { #category : 'examples' }

--- a/src/MicroUML-Editor/MicroUMLBrowserNodeInteraction.class.st
+++ b/src/MicroUML-Editor/MicroUMLBrowserNodeInteraction.class.st
@@ -4,8 +4,9 @@ Class {
 	#instVars : [
 		'box'
 	],
-	#category : 'MicroUML-Editor',
-	#package : 'MicroUML-Editor'
+	#category : 'MicroUML-Editor-Roassal3',
+	#package : 'MicroUML-Editor',
+	#tag : 'Roassal3'
 }
 
 { #category : 'menus' }

--- a/src/MicroUML-Editor/MicroUMLCanvasController.class.st
+++ b/src/MicroUML-Editor/MicroUMLCanvasController.class.st
@@ -4,8 +4,9 @@ Class {
 	#instVars : [
 		'builder'
 	],
-	#category : 'MicroUML-Editor',
-	#package : 'MicroUML-Editor'
+	#category : 'MicroUML-Editor-Roassal3',
+	#package : 'MicroUML-Editor',
+	#tag : 'Roassal3'
 }
 
 { #category : 'accessing' }
@@ -58,17 +59,25 @@ MicroUMLCanvasController >> increaseMargin [
 MicroUMLCanvasController >> onShape: aRSCanvas [
 
 	super onShape: aRSCanvas.
-	aRSCanvas when: RSKeyDown send: #processKeyDown: to: self
+	aRSCanvas when: RSKeyStroke send: #processKeystroke: to: self
 ]
 
 { #category : 'events' }
 MicroUMLCanvasController >> processKeyDown: event [
-
-	event shiftKeyPressed ifTrue: [
+	event keyValue = $< codePoint ifTrue: [ ^self decreaseMargin ].
+	event keyValue = $> codePoint ifTrue: [ ^ self increaseMargin ]
+	"event shiftKeyPressed ifTrue: [
 			| keyName |
 			keyName := event keyName.
 			keyName = #PERIOD ifTrue: [ ^ self increaseMargin ].
-			keyName = #COMMA ifTrue: [ ^ self decreaseMargin ] ]
+			keyName = #COMMA ifTrue: [ ^ self decreaseMargin ] ]"
+]
+
+{ #category : 'events' }
+MicroUMLCanvasController >> processKeystroke: event [
+
+	event keyValue = $< codePoint ifTrue: [ ^ self decreaseMargin ].
+	event keyValue = $> codePoint ifTrue: [ ^ self increaseMargin ]
 ]
 
 { #category : 'hooks' }

--- a/src/MicroUML-Editor/MicroUMLClassDiagramNodeInteraction.class.st
+++ b/src/MicroUML-Editor/MicroUMLClassDiagramNodeInteraction.class.st
@@ -4,8 +4,9 @@ Class {
 	#instVars : [
 		'diagram'
 	],
-	#category : 'MicroUML-Editor',
-	#package : 'MicroUML-Editor'
+	#category : 'MicroUML-Editor-Roassal3',
+	#package : 'MicroUML-Editor',
+	#tag : 'Roassal3'
 }
 
 { #category : 'menus' }

--- a/src/MicroUML-Editor/MicroUMLEditor.class.st
+++ b/src/MicroUML-Editor/MicroUMLEditor.class.st
@@ -8,8 +8,9 @@ Class {
 		'liveDrawingButton',
 		'builder'
 	],
-	#category : 'MicroUML-Editor',
-	#package : 'MicroUML-Editor'
+	#category : 'MicroUML-Editor-Spec2',
+	#package : 'MicroUML-Editor',
+	#tag : 'Spec2'
 }
 
 { #category : 'examples' }

--- a/src/MicroUML-Editor/RSAthensMorph.extension.st
+++ b/src/MicroUML-Editor/RSAthensMorph.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'RSAthensMorph' }
+
+{ #category : '*MicroUML-Editor' }
+RSAthensMorph >> handleKeystroke: anEvent [
+	super handleKeystroke: anEvent.
+	eventProcessor eventKeystroke: anEvent
+]

--- a/src/MicroUML-Editor/RSKeyStroke.class.st
+++ b/src/MicroUML-Editor/RSKeyStroke.class.st
@@ -1,0 +1,7 @@
+Class {
+	#name : 'RSKeyStroke',
+	#superclass : 'RSKeyboardEvent',
+	#category : 'MicroUML-Editor-Roassal3',
+	#package : 'MicroUML-Editor',
+	#tag : 'Roassal3'
+}

--- a/src/MicroUML-Editor/TMicroUMLRSKeyCharacter.trait.st
+++ b/src/MicroUML-Editor/TMicroUMLRSKeyCharacter.trait.st
@@ -1,0 +1,21 @@
+Trait {
+	#name : 'TMicroUMLRSKeyCharacter',
+	#instVars : [
+		'keyCharacter'
+	],
+	#category : 'MicroUML-Editor-Roassal3',
+	#package : 'MicroUML-Editor',
+	#tag : 'Roassal3'
+}
+
+{ #category : 'accessing' }
+TMicroUMLRSKeyCharacter >> keyCharacter [
+
+	^ keyCharacter
+]
+
+{ #category : 'accessing' }
+TMicroUMLRSKeyCharacter >> keyCharacter: aCharacter [
+
+	keyCharacter := aCharacter
+]


### PR DESCRIPTION
The MicroUML editor could not respond to `<` and `>` due to variations of keyboard layouts.
The real problem is rather deeper that Pharo distributes the `keyStroke` events with characters typed with modifier keys, such as `<` and `>`, but does NOT distribute `keyDown` nor `keyUp` events.
And, Roassal3's `RSAthensMorph` does not handle the `keyStroke` event.
I made a quick implementation of `RSKeyStroke` event and modified the `RSEventProcessor` to relay the keystroke event as `RSKeyStroke` announcement.
This modification rather needs to be done in Roassal3. I'll write a PR for that.